### PR TITLE
Add nuxt3 + vite support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 ## Features
 
 - Zero configuration
+- Nuxt 3 with Vite support
 - Nuxt webpack configuration
 - Nuxt plugins support
 - Story discovery from nuxt modules


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: nuxt/nuxt.js#10970" -->

This adds Nuxt3 and Vite support. The main idea is to use nuxt to render the stories and expose them at `/_storybook`. Thus, we completely skip the custom config of the webpack/vite storybook build process and ensure that all components behave the same as in the production build. This strategy is taken from https://github.com/storybookjs/storybook/blob/next/examples/standalone-preview.

Currently, I only have a working prototype that requires manual config locally. Follow these steps:

- Add `@storybook/vue3` as dependency
- Add `alias: { global: 'global.ts' }` to `nuxt.config` and a `global.ts` in the root folder with the following content:
```ts
import { JSDOM } from 'jsdom'

const myGlobal = globalThis
const dom = new JSDOM()
myGlobal.window = dom.window as any as Window & typeof globalThis
myGlobal.document = dom.window.document
myGlobal.location = dom.window.location
// Needed for storybook
// @ts-ignore -- this is a workaround
myGlobal.PREVIEW_URL = '_storybook/external-iframe'
export default myGlobal
export const window = myGlobal
```
- Add `"storybook": "start-storybook -p 6006 --preview-url=http://localhost:3000/_storybook/external-iframe --no-manager-cache",` to `package.json`
- Add `pages/_storybook/external-iframe.vue` with the following content https://github.com/JabRef/JabRefOnline/blob/main/pages/_storybook/external-iframe.vue

Now you can start the developer sever `nuxi dev` and than the storybook server `yarn storybook`. Your stories should now appear at `localhost:6006` (or whatever address yarn storybook prints). 

Current blockers to make this a straightforward module that one can install:
- Polyfill in nuxt3 for globals: https://github.com/nuxt/nuxt.js/issues/12830
- Ability to add custom commands to nuxi, like `nuxi storybook`: https://github.com/nuxt/nuxt.js/issues/13634
- Ability to add a custom page and route from a module. There is `addServerMiddleware` but I couldn't figure how to easily render a vue component (using the nuxt pipeline) and return the generated html.
- Ability to forward a request from a h3 route to an existing server (maybe thats already possible, but I couldn't figure out how to do this).

@pi0 @danielroe I hope its okay to cc you here to get your input on these open points.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
