### PR TITLE
(v4) include plugins with mode: 'all' for bridge compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,7 @@ async function buildNuxt (options: StorybookOptions) {
    */
   nuxt.options.plugins = nuxt.options.plugins.filter((plugin) => {
     if (typeof plugin === 'object') {
-      return !plugin.mode || plugin.mode === 'client'
+      return !plugin.mode || plugin.mode === 'client' || plugin.mode === 'all'
     }
 
     if (typeof plugin === 'string' && plugin.match(/\.server\.?(.*)\.(ts|js)/)) {


### PR DESCRIPTION
This is essentially a backport of https://github.com/nuxt-modules/storybook/pull/405.

We need this fix to use Nuxt/Bridge