### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Integrate [Storybook](http://storybook.js.org) into your [Nuxt](https://nuxt.com
 ## Installing
 
 ```
-pnpm add -D @nuxtjs/storybook
+npx nuxi@latest module add storybook
 ```
 
 Update your `nuxt.config`:

--- a/docs/content/0.index.md
+++ b/docs/content/0.index.md
@@ -13,7 +13,7 @@ cta:
 secondary:
   - Star on GitHub →
   - https://github.com/nuxt-modules/storybook
-snippet: pnpm add -D @nuxtjs/storybook
+snippet: npx nuxi@latest module add storybook
 ---
 
 #title

--- a/docs/content/1.getting-started/1.setup.md
+++ b/docs/content/1.getting-started/1.setup.md
@@ -5,22 +5,9 @@ Using Storybook  in your Nuxt project is only one command away ✨
 ## Installation
 
 1. Install `@nuxtjs/storybook` dependency to your project:
-
-::code-group
-
-```bash [yarn]
-yarn add -D @nuxtjs/storybook 
+```bash
+npx nuxi@latest module add storybook
 ```
-
-```bash [npm]
-npm install -D @nuxtjs/storybook 
-```
-
-```sh [pnpm]
-pnpm i -D @nuxtjs/storybook 
-```
-
-::
 
 2. Add it to your `modules` section in your `nuxt.config`:
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
