### PR TITLE
fix: do not change nuxt devtools config

### DIFF
--- a/src/storybook.ts
+++ b/src/storybook.ts
@@ -67,8 +67,6 @@ export async function setupStorybook(options: any, nuxt: Nuxt) {
       config.optimizeDeps ??=  {}
       config.optimizeDeps.include = config.optimizeDeps.include || []
 
-      nuxt.options.devtools = { enabled: true} 
-
       config.server ??= {}
       config.server.proxy ??= {}
 
@@ -102,7 +100,6 @@ export async function setupStorybook(options: any, nuxt: Nuxt) {
       logger.info(' ')
       logger.info('✔ Storybook build done  ')
       logger.info('  ')
-      nuxt.options.devtools = {enabled:true} 
       process.env.__STORYBOOK__ = JSON.stringify( options )     
     })
     


### PR DESCRIPTION
Removes setting the `devtools` option, as users of the module can decide that on their own.