### PR TITLE
fix!: improve handling of module options

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -4,49 +4,26 @@ import { setupStorybook } from './storybook'
 
 export interface ModuleOptions {
   /**
-   * StorybookAPI URL
-   * @default process.env.STORYBOOK_URL
-   * @example 'http://localhost:6006'
-   * @type string
-   */
-  url?: string
-
-  /**
-   * StorybookVersion
-   * @default 'v7'
-   * @type string
-   * @example 'v8'
-   */
-  version?: 'v7' | 'v8'
-
-  /**
-   * StorybookCookie Name
-   * @default 'storybook_jwt'
-   * @type string
-  */
-  cookieName?: string
-
-  /**
-   * Add Storybook  in Nuxt Devtools
+   * The route where the Storybook application will be available in development mode.
    *
-   * Please read the instructions on https://storybook.nuxtjs.org/devtools
-   *
-   * @default false
-  */
-  devtools?: boolean
-
-  /**
-   * Storybook Route
-   * @default '/__storybook_route'
+   * @default '/_storybook'
    */
-  storybookRoute?: string
+  route: string
 
   /**
-   * Storybook Port
+   * The port where the Storybook application server will be started.
+   *
    * @default 6006
-   * @type number
    */
-  port?: number
+  port: number
+
+  /**
+   * The host where the Storybook application server will be started.
+   *
+   * @default process.env.STORYBOOK_HOST or 'http://localhost'
+   * @example 'http://localhost'
+   */
+  host: string
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -58,12 +35,9 @@ export default defineNuxtModule<ModuleOptions>({
     },
   },
   defaults: {
-    url: process.env.STORYBOOK_URL || 'http://localhost:6006',
-    storybookRoute: '/__storybook_route',
+    host: process.env.STORYBOOK_HOST || 'http://localhost:6006',
+    route: '/_storybook',
     port: 6006,
-    version: 'v8',
-    cookieName: 'sb_session',
-    devtools: false,
   },
   async setup(options, nuxt) {
     

--- a/src/module.ts
+++ b/src/module.ts
@@ -35,7 +35,7 @@ export default defineNuxtModule<ModuleOptions>({
     },
   },
   defaults: {
-    host: import.meta.env.STORYBOOK_URL || 'http://localhost:6006',
+    host: import.meta.env.STORYBOOK_HOST || 'http://localhost:6006',
     route: '/_storybook',
     port: 6006,
   },

--- a/src/storybook.ts
+++ b/src/storybook.ts
@@ -5,12 +5,13 @@ import type { Nuxt } from 'nuxt/schema'
 import { getPort } from 'get-port-please'
 import { extendViteConfig } from '@nuxt/kit'
 import { logger } from '@nuxt/kit'
+import type { ModuleOptions } from './module'
 
 
-export async function setupStorybook(options: any, nuxt: Nuxt) {
-  const STORYBOOK_ROUTE = options.storybookRoute || '/__storybook_route'
+export async function setupStorybook(options: ModuleOptions, nuxt: Nuxt) {
+  const STORYBOOK_ROUTE = options.route
   const STORYBOOK_PORT =  await getPort({ ports: [options.port || 6006, 6007, 6008, 6009, 6010]})
-  const STORYBOOK_HOST = options.storybookHost || 'http://localhost'
+  const STORYBOOK_HOST = options.host
   const STORYBOOK_URL = + STORYBOOK_HOST + STORYBOOK_PORT == 80 ? '' : `:${STORYBOOK_PORT}`
    
   const projectDir = resolve(nuxt.options.rootDir)


### PR DESCRIPTION
- Remove some of the unused module options
- Change the behavior of the route to default to `_storybook` as described in the docs
- Rename some of the options (the `storybook` prefix  is unnecessary in my opinion). This is a breaking change, although I doubt many users used these options (the `storybookUrl` option was not even working) 