### PR TITLE
chore: fix publishing of nightly releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,6 @@ jobs:
           matrix.os == 'ubuntu-latest' &&
           !contains(github.event.head_commit.message, '[skip-release]') &&
           !startsWith(github.event.head_commit.message, 'docs')
-        run: pnpm publish --recursive --tag next --access public --report-summary --no-git-checks
+        run: pnpm publish --recursive --tag next --access public --report-summary --no-git-checks --force
         env:
             NODE_AUTH_TOKEN: ${{secrets.NPMJS_TOKEN}}


### PR DESCRIPTION
Currently fails with "There are no new packages that should be published". Since we don't update the version before publishing to the `next` tag, we use the `--force` argument to overwrite the version check. This hopefully fixes the publishing of the nightly release.