### PR TITLE
fix: fix order of vite vue plugin

### DIFF
--- a/examples/showcase/components/globalComp.global.vue
+++ b/examples/showcase/components/globalComp.global.vue
@@ -1,0 +1,3 @@
+<template>
+  <h1>Global Component</h1>
+</template>

--- a/examples/showcase/components/globalComp.stories.ts
+++ b/examples/showcase/components/globalComp.stories.ts
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+import MyGlobalComp from './globalComp.global.vue'
+
+// More on how to set up stories at: https://storybook.js.org/docs/vue/writing-stories/introduction
+
+const meta = {
+  title: 'Features/Global components',
+  component: MyGlobalComp,
+  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/vue/writing-docs/autodocs
+  tags: ['autodocs'],
+} satisfies Meta<typeof MyGlobalComp>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const GlobalComponent: Story = {
+  args: {},
+}

--- a/packages/storybook-nuxt/src/preset.ts
+++ b/packages/storybook-nuxt/src/preset.ts
@@ -105,7 +105,9 @@ async function defineNuxtConfig(baseConfig: {
         const plugins = extendedConfig.plugins || []
 
         // Find the index of the plugin with name 'vite:vue'
-        const index = plugins.findIndex((plugin) => plugin.name === 'vite:vue')
+        const index = plugins.findIndex(
+          (plugin) => plugin && 'name' in plugin && plugin.name === 'vite:vue',
+        )
 
         // Check if the plugin was found
         if (index !== -1) {

--- a/packages/storybook-nuxt/src/preset.ts
+++ b/packages/storybook-nuxt/src/preset.ts
@@ -100,7 +100,9 @@ async function defineNuxtConfig(baseConfig: {
 
     nuxt.hook('vite:extendConfig', (config, { isClient }) => {
       if (isClient) {
-        const plugins = baseConfig.plugins
+        extendedConfig = mergeConfig(config, baseConfig)
+
+        const plugins = extendedConfig.plugins || []
 
         // Find the index of the plugin with name 'vite:vue'
         const index = plugins.findIndex((plugin) => plugin.name === 'vite:vue')
@@ -110,10 +112,10 @@ async function defineNuxtConfig(baseConfig: {
           // Replace the plugin with the new one using vuePlugin()
           plugins[index] = vuePlugin()
         } else {
-          plugins.push(vuePlugin())
+          plugins.unshift(vuePlugin())
         }
-        baseConfig.plugins = plugins
-        extendedConfig = mergeConfig(config, baseConfig)
+
+        extendedConfig.plugins = plugins
       }
     })
   })

--- a/packages/storybook-nuxt/src/preset.ts
+++ b/packages/storybook-nuxt/src/preset.ts
@@ -112,6 +112,8 @@ async function defineNuxtConfig(baseConfig: {
           // Replace the plugin with the new one using vuePlugin()
           plugins[index] = vuePlugin()
         } else {
+          // Vue plugin should be the first registered user plugin so that it will be added directly after Vite's core plugins
+          // and transforms global vue components before nuxt:components:imports.
           plugins.unshift(vuePlugin())
         }
 


### PR DESCRIPTION
`@vitejs/plugin-vue` should be the first registered user plugin so that it will be added directly after Vite's core plugins and transforms global vue compoments before nuxt:components:imports. The transform stack order can be reviewed with the `vite-plugin-inspect` plugin.

This fixes the use of global components in projects or modules.
Fixes https://github.com/storybook-vue/storybook-nuxt/issues/4.