### PR TITLE
fix: use appId and buildId as fallbacks, use `vite:configResolved` hook 

### DIFF
--- a/packages/storybook-nuxt/src/preset.ts
+++ b/packages/storybook-nuxt/src/preset.ts
@@ -64,12 +64,14 @@ async function defineNuxtConfig(baseConfig: {
   )
 
   nuxt = await loadNuxt({
-    rootDir: baseConfig.root,
+    cwd: baseConfig.root,
     ready: false,
     dev: false,
-
     overrides: {
-      buildDir: '.nuxt-storybook',
+      // @ts-expect-error: this is actually correct, but would require to use generated types
+      appId: 'nuxt-app',
+      buildId: 'storybook',
+      ssr: false,
     },
   })
 
@@ -104,7 +106,7 @@ async function defineNuxtConfig(baseConfig: {
   await nuxt.ready()
   return new Promise<{ viteConfig: ViteConfig; nuxt: Nuxt }>(
     (resolve, reject) => {
-      nuxt.hook('vite:extendConfig', (config, { isClient }) => {
+      nuxt.hook('vite:configResolved', (config, { isClient }) => {
         if (isClient) {
           extendedConfig = mergeConfig(config, baseConfig)
 


### PR DESCRIPTION
Similar to https://github.com/nuxt/test-utils/blob/66b23ae6f3d717690551ff1908647ff0f0cfa63b/src/config.ts#L37-L38