### PR TITLE
chore: tell renovate to pin all development and doc dependencies

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,13 +9,13 @@
     // Use "chore" type for all commit messages
     ':semanticCommitTypeAll(chore)',
     // Pin all dev dependencies following https://docs.renovatebot.com/dependency-pinning/
-    ':pinDevDependencies'
+    ':pinDevDependencies',
   ],
   packageRules: [
     {
       // Pin all docs dependencies following https://docs.renovatebot.com/dependency-pinning/
-      "matchFileNames": ["docs/package.json"],
-      "rangeStrategy": "pin"
+      matchFileNames: ['docs/package.json'],
+      rangeStrategy: 'pin',
     },
     {
       // Bump all @storybook/* packages so that always the latest version is used

--- a/renovate.json5
+++ b/renovate.json5
@@ -8,8 +8,15 @@
     'schedule:weekends',
     // Use "chore" type for all commit messages
     ':semanticCommitTypeAll(chore)',
+    // Pin all dev dependencies following https://docs.renovatebot.com/dependency-pinning/
+    ':pinDevDependencies'
   ],
   packageRules: [
+    {
+      // Pin all docs dependencies following https://docs.renovatebot.com/dependency-pinning/
+      "matchFileNames": ["docs/package.json"],
+      "rangeStrategy": "pin"
+    },
     {
       // Bump all @storybook/* packages so that always the latest version is used
       matchPackagePatterns: ['storybook', '@storybook/*'],


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Following https://docs.renovatebot.com/dependency-pinning/ since we have a bit of problems with handling the dependencies currently. In particular, https://github.com/nuxt-modules/storybook/pull/690 updates a package (in the lock file) that is not working, and its not easy to just revert that particular update.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
