### PR TITLE
fix: fix error due to import json attribute (and deactivate storybook version check)

### DIFF
--- a/packages/nuxt-module/src/storybook.ts
+++ b/packages/nuxt-module/src/storybook.ts
@@ -4,12 +4,8 @@ import { getPort } from 'get-port-please'
 import type { ModuleOptions } from './module'
 import { withTrailingSlash } from 'ufo'
 import { colors, logger } from './logger'
-import {
-  cache as storybookCache,
-  type PackageJson,
-} from '@storybook/core-common'
+import { cache as storybookCache } from '@storybook/core-common'
 import { buildDevStandalone, withTelemetry } from '@storybook/core-server'
-import storybookPackageJson from '@storybook/core-server/package.json' with { type: 'json' }
 
 const buildLogger = logger.withTag('build')
 
@@ -57,7 +53,10 @@ export async function setupStorybook(options: ModuleOptions, nuxt: Nuxt) {
     configDir: resolve(projectDir, './.storybook'),
     configType: 'DEVELOPMENT',
     cache: storybookCache,
-    packageJson: storybookPackageJson as PackageJson,
+    packageJson: { version: '8.2.2' },
+    // Don't check for storybook updates (we're using the latest version)
+    versionUpdates: false,
+    quiet: options.logLevel < 4, // 4 = debug
   } satisfies Parameters<typeof buildDevStandalone>[0]
 
   if (!nuxt.options.dev) return


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Fixes https://github.com/nuxt-modules/storybook/issues/704

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Instead of actually loading the package json, we just pass a javascript object with a `version` field. That is the only thing used by storybook. It's a temporary workaround until https://github.com/storybookjs/storybook/pull/28594 is merged.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
