### PR TITLE
fix: remove Nuxt context conflict

### DIFF
--- a/packages/storybook-addon/src/preview.ts
+++ b/packages/storybook-addon/src/preview.ts
@@ -4,7 +4,7 @@
  * https://github.com/storybookjs/storybook/blob/main/docs/configure/index.md#configure-story-rendering
  *
  * We use it to load the Nuxt app in the preview iframe.
- * This should contain the same setup as the what Nuxt does in the background.
+ * This should contain the same setup as what Nuxt does in the background.
  * https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/app/entry.ts
  */
 
@@ -34,9 +34,15 @@ setup(async (vueApp, storyContext) => {
   if (!key) {
     throw new Error('StoryContext is not provided')
   }
-  const nuxtAppName = `nuxt-app-${key}`
-  const nuxtCtx = getContext(nuxtAppName)
-  if (nuxtCtx.tryUse()) {
+
+  // This is the `nuxtApp._name`, it's the same for all stories.
+  const appId = 'nuxt-app'
+  const globalCtx = getContext(appId)
+
+  // This is the `nuxtApp.globalName`, it's different for each story.
+  const storyNuxtAppName = `nuxt-app-${key}`
+  const storyNuxtCtx = getContext(storyNuxtAppName)
+  if (storyNuxtCtx.tryUse()) {
     // Nothing to do, the Nuxt app is already created
     return
   }
@@ -62,12 +68,14 @@ setup(async (vueApp, storyContext) => {
 
   const nuxt = createNuxtApp({
     vueApp,
-    globalName: nuxtAppName,
+    globalName: storyNuxtAppName,
   })
+
+  globalCtx.set(nuxt, true)
+
   await applyPlugins(nuxt, pluginsTyped)
   await nuxt.hooks.callHook('app:created', vueApp)
   await nuxt.hooks.callHook('app:beforeMount', vueApp)
-  nuxtCtx.set(nuxt, true)
 
   // TODO: The following are usually called after the app is mounted
   // but currently storybook doesn't provide a hook to do that


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
Related #661

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
This PR updates the global nuxt context, setting its `nuxt` property to the story's nuxt when setting up the current story.

Previously, when navigating from one story to another story, Nuxt would get the context using the app's `_name`, which is the same for all stories, instead of using the `globalName`, which is different for each story.
