### PR TITLE
feat: Exposing the https options for Storybook dev server

### DIFF
--- a/docs/content/1.getting-started/2.options.md
+++ b/docs/content/1.getting-started/2.options.md
@@ -16,5 +16,42 @@ export default {
 ```
 
 - `enabled`: Enable or disable the module. This can be useful to control and disable storybook in layers or in extended projects.
+
   - **type**: `boolean`
   - **default**: `true`
+
+- `route`: The route where the Storybook application will be available in development mode.
+
+  - **type**: `string`
+  - **default**: `/_storybook`
+
+- `port`: The port where the Storybook application server will be started.
+
+  - **type**: `number`
+  - **default**: `6006`
+
+- `host`: The host where the Storybook application server will be started.
+
+  - **type**: `string`
+  - **default**: Environment variable `STORYBOOK_HOST` or `http://localhost`
+
+- `logLevel`: Log level for the terminal output.
+
+  - **type**: `number`
+  - **default**: `nuxt.options.logLevel`
+
+- `https`: Serve Storybook over HTTPS.
+  _Note: You must provide your own certificate information. You can use https://mkcert.dev/ for example._
+
+  - **type**: `boolean` or `{ key: string; cert: string }`
+  - **default**: `false`
+  - **example**:
+
+    ```ts [nuxt.config.ts]
+    storybook: {
+      https: {
+        key: './secrets/key.pem',
+        cert: './secrets/cert.pem',
+      }
+    }
+    ```

--- a/docs/content/1.getting-started/2.options.md
+++ b/docs/content/1.getting-started/2.options.md
@@ -41,6 +41,7 @@ export default {
   - **default**: `nuxt.options.logLevel`
 
 - `https`: Serve Storybook over HTTPS.
+
   _Note: You must provide your own certificate information. You can use https://mkcert.dev/ for example._
 
   - **type**: `boolean` or `{ key: string; cert: string }`

--- a/packages/nuxt-module/src/module.ts
+++ b/packages/nuxt-module/src/module.ts
@@ -41,6 +41,21 @@ export interface ModuleOptions {
    * @default true
    */
   enabled: boolean
+
+  /**
+   * Whether to enable HTTPS.
+   *
+   * @default false
+   *
+   * @example
+   * ```
+   * https: {
+   *   key: './server.key',
+   *   cert: './server.crt'
+   * }
+   * ```
+   */
+  https: boolean | { key: string; cert: string }
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -61,6 +76,7 @@ export default defineNuxtModule<ModuleOptions>({
     port: 6006,
     logLevel: nuxt.options.logLevel === 'silent' ? 0 : 3,
     enabled: true,
+    https: false,
   }),
   async setup(options, nuxt) {
     if (import.meta.env?.__STORYBOOK__ || !options.enabled) return

--- a/packages/nuxt-module/src/storybook.ts
+++ b/packages/nuxt-module/src/storybook.ts
@@ -57,6 +57,9 @@ export async function setupStorybook(options: ModuleOptions, nuxt: Nuxt) {
     // Don't check for storybook updates (we're using the latest version)
     versionUpdates: false,
     quiet: options.logLevel < 4, // 4 = debug
+    https: Boolean(options.https),
+    sslCert: typeof options.https === 'object' ? options.https.cert : undefined,
+    sslKey: typeof options.https === 'object' ? options.https.key : undefined,
   } satisfies Parameters<typeof buildDevStandalone>[0]
 
   if (!nuxt.options.dev) return


### PR DESCRIPTION
### 📚 Description
With this module it's easy to set-up a storybook env. but it isn't possible to use a ssl certificate like the CLI does: 
`storybook dev -p 6006 --https --ssl-cert ./secrets/cert.pem --ssl-key ./secrets/key.pem`.

To make that possible with this module I've added/exposed the https options. I used the same format as Nuxt [devServer.https](https://nuxt.com/docs/api/nuxt-config#https) options.  

You could even argue that we could just reuse the https options from the devServer section directly if they're defined. But to keep it flexible I've kept them separate. 

### How to test
- Generate a SSL key & cert with e.g. https://github.com/Subash/mkcert
- Add those to the playground folder
- Add in the nuxt.config.ts of the playground with the right paths:
```
storybook: {
    https: {
      key: './key.pem',
      cert: './cert.pem',
    },
},
```
- `pnpm dev`
- See the storybook running on https://[...] 