### PR TITLE
fix: remove Storybook version from `storybook.ts`

### DIFF
--- a/packages/nuxt-module/src/storybook.ts
+++ b/packages/nuxt-module/src/storybook.ts
@@ -53,7 +53,6 @@ export async function setupStorybook(options: ModuleOptions, nuxt: Nuxt) {
     configDir: resolve(projectDir, './.storybook'),
     configType: 'DEVELOPMENT',
     cache: storybookCache,
-    packageJson: { version: '8.3.0' },
     // Don't check for storybook updates (we're using the latest version)
     versionUpdates: false,
     quiet: options.logLevel < 4, // 4 = debug

--- a/packages/nuxt-module/src/storybook.ts
+++ b/packages/nuxt-module/src/storybook.ts
@@ -53,7 +53,7 @@ export async function setupStorybook(options: ModuleOptions, nuxt: Nuxt) {
     configDir: resolve(projectDir, './.storybook'),
     configType: 'DEVELOPMENT',
     cache: storybookCache,
-    packageJson: { version: '8.2.7' },
+    packageJson: { version: '8.3.0' },
     // Don't check for storybook updates (we're using the latest version)
     versionUpdates: false,
     quiet: options.logLevel < 4, // 4 = debug


### PR DESCRIPTION
<!--
☝️ PR title should follow conventional commits (https://conventionalcommits.org).
In particular, the title should start with one of the following types:

- docs: 📖 Documentation (updates to the documentation or readme)
- fix: 🐞 Bug fix (a non-breaking change that fixes an issue)
- feat: ✨ New feature/enhancement (a non-breaking change that adds functionality or improves existing one)
- feat!/fix!: ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- chore: 🧹 Chore (updates to the build process or auxiliary tools and libraries)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
The Storybook versions in the `package.json` were updated, but the same change needs to be added to the `storybook.ts` to prevent version conflicts.

Currently, with nightly, we get the following error:
```
WARN The following packages are incompatible with Storybook 8.2.7 as they depend on different major versions of Storybook packages:
WARN - @nuxtjs/storybook@8.3.0-28764731.a9bf66d
WARN  Repo: https://storybook.nuxtjs.org
WARN - @storybook-vue/nuxt@8.3.0-28764731.a9bf66d
WARN  Repo: https://storybook.nuxtjs.org
WARN - storybook@8.2.9
WARN  Repo: https://github.com/storybookjs/storybook/tree/next/code/lib/cli
WARN - @storybook/vue3@8.2.9
WARN  Repo: https://github.com/storybookjs/storybook/tree/next/code/renderers/vue3
WARN - @storybook/addon-links@8.2.9
WARN  Repo: https://github.com/storybookjs/storybook/tree/next/code/addons/links
WARN - @storybook/builder-vite@8.2.9
WARN  Repo: https://github.com/storybookjs/storybook/tree/next/code/builders/builder-vite/#readme
WARN - @storybook/addon-essentials@8.2.9
WARN  Repo: https://github.com/storybookjs/storybook/tree/next/code/addons/essentials
WARN - @storybook/addon-interactions@8.2.9
WARN  Repo: https://github.com/storybookjs/storybook/tree/next/code/addons/interactions
WARN - @storybook/test@8.2.9
WARN  Repo: https://github.com/storybookjs/storybook/tree/next/code/lib/test
WARN - @storybook/blocks@8.2.9
WARN  Repo: https://github.com/storybookjs/storybook/tree/next/code/lib/blocks
WARN 
WARN 
WARN Please consider updating your packages or contacting the maintainers for compatibility details.
WARN For more on Storybook 8 compatibility, see the linked GitHub issue:
WARN https://github.com/storybookjs/storybook/issues/26031

 ERROR  Storybook failed to load the following preset: @storybook-vue/nuxt/preset.                                                                                                              nuxt:storybook:build 5:37:16 PM

Please check whether your setup is correct, the Storybook dependencies (and their peer dependencies) are installed correctly and there are no package version clashes.

```
