### PR TITLE
docs: module will not automatically generate a basic configuration

### DIFF
--- a/docs/content/1.getting-started/1.setup.md
+++ b/docs/content/1.getting-started/1.setup.md
@@ -29,6 +29,8 @@ export default {
 
 ::
 
+3. Prepare [Storybook config Files](#storybook-config-files)
+
 ::alert{type="success"}
 That's it! You can now use `Storybook` in your Nuxt app ✨
 ::
@@ -80,9 +82,7 @@ When running `npm run dev`, this module will look for these files:
 - `.storybook/main.{ts,js}`
 - `.storybook/preview.{js,cjs,mjs,ts}`
 
-If these files don't exist, the module will automatically generate a basic configuration for them, so you don't have to create these files manually.
-
-You can create these files by running the following command:
+You can create these files manually or by running the following command:
 
 ```bash
 npx storybook-nuxt init

--- a/docs/content/1.getting-started/1.setup.md
+++ b/docs/content/1.getting-started/1.setup.md
@@ -29,7 +29,7 @@ export default {
 
 ::
 
-3. Prepare [Storybook config Files](#storybook-config-files)
+3. Prepare [Storybook config files](#storybook-config-files).
 
 ::alert{type="success"}
 That's it! You can now use `Storybook` in your Nuxt app ✨


### PR DESCRIPTION
<!--
☝️ PR title should follow conventional commits (https://conventionalcommits.org).
In particular, the title should start with one of the following types:

- docs: 📖 Documentation (updates to the documentation or readme)
- fix: 🐞 Bug fix (a non-breaking change that fixes an issue)
- feat: ✨ New feature/enhancement (a non-breaking change that adds functionality or improves existing one)
- feat!/fix!: ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- chore: 🧹 Chore (updates to the build process or auxiliary tools and libraries)
-->

### 🔗 Linked issue

Resolves #793

### 📚 Description

Actually module will not automatically generate a basic configuration and you have to create
`.storybook/main.{ts,js}`
`.storybook/preview.{js,cjs,mjs,ts}`
