### PR TITLE
Fix: Extend the server proxy preset to also fetch SSG NuxtIslands

### DIFF
--- a/packages/storybook-addon/src/preset.ts
+++ b/packages/storybook-addon/src/preset.ts
@@ -354,7 +354,7 @@ async function getPackageDir(packageName: string) {
 
 export function getNuxtProxyConfig(nuxt: Nuxt) {
   const port = nuxt.options.runtimeConfig.app.port ?? 3000
-  const route = '^/(_nuxt|_ipx|_icon|__nuxt_devtools__)'
+  const route = '^/(_nuxt|_ipx|_icon|__nuxt_devtools__|__nuxt_island)'
   const proxy = {
     [route]: {
       target: `http://localhost:${port}`,


### PR DESCRIPTION
### 📚 Description
This PR extends the preset for the server proxy, to also allow the fetching of NuxtIsland components from the dev server.

Standalone stories for NuxtIslands work fine. But when you have a component that has a NuxtIsland component in it, it won't render (properly) because it can't find the server only parts in the Storybook server. With this PR those routes are exposed and make the stories render.

There's one thing left to make NuxtIsland's work without any user changes needed: a Suspense wrapper, but I wasn't too sure if/where that should be enabled by default. 

## Reproduction stories
https://github.com/nuxt-modules/storybook/compare/main...brandondv:nuxtjs-storybook:feature/child-nuxt-island-stories