### PR TITLE
fix: readd vue-tempate-compilation plugin

### DIFF
--- a/packages/storybook-addon/src/preset.ts
+++ b/packages/storybook-addon/src/preset.ts
@@ -159,16 +159,6 @@ function mergeViteConfig(
     plugins.unshift(vuePlugin())
   }
 
-  // Remove the 'storybook:vue-template-compilation' plugin because it yields out-of-memory issues
-  // const templatePluginIndex = plugins?.findIndex(
-  //   (plugin) =>
-  //     plugin &&
-  //     'name' in plugin &&
-  //     plugin.name === 'storybook:vue-template-compilation',
-  // )
-  // if (templatePluginIndex !== -1) {s
-  //   plugins.splice(templatePluginIndex, 1)
-  // }
   extendedConfig.plugins = plugins
 
   // Storybook adds 'vue' as dependency that should be optimized, but nuxt explicitly excludes it from pre-bundling

--- a/packages/storybook-addon/src/preset.ts
+++ b/packages/storybook-addon/src/preset.ts
@@ -160,15 +160,15 @@ function mergeViteConfig(
   }
 
   // Remove the 'storybook:vue-template-compilation' plugin because it yields out-of-memory issues
-  const templatePluginIndex = plugins?.findIndex(
-    (plugin) =>
-      plugin &&
-      'name' in plugin &&
-      plugin.name === 'storybook:vue-template-compilation',
-  )
-  if (templatePluginIndex !== -1) {
-    plugins.splice(templatePluginIndex, 1)
-  }
+  // const templatePluginIndex = plugins?.findIndex(
+  //   (plugin) =>
+  //     plugin &&
+  //     'name' in plugin &&
+  //     plugin.name === 'storybook:vue-template-compilation',
+  // )
+  // if (templatePluginIndex !== -1) {s
+  //   plugins.splice(templatePluginIndex, 1)
+  // }
   extendedConfig.plugins = plugins
 
   // Storybook adds 'vue' as dependency that should be optimized, but nuxt explicitly excludes it from pre-bundling

--- a/playground/package.json
+++ b/playground/package.json
@@ -17,6 +17,7 @@
     "@storybook/addon-interactions": "8.4.7",
     "@storybook/addon-links": "8.4.7",
     "nuxt": "3.14.1592",
+    "vue": "^3.3.4",
     "storybook": "8.4.7",
     "vite-plugin-inspect": "0.10.3"
   }

--- a/playground/package.json
+++ b/playground/package.json
@@ -17,7 +17,7 @@
     "@storybook/addon-interactions": "8.4.7",
     "@storybook/addon-links": "8.4.7",
     "nuxt": "3.14.1592",
-    "vue": "^3.3.4",
+    "vue": "3.5.13",
     "storybook": "8.4.7",
     "vite-plugin-inspect": "0.10.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,6 +347,9 @@ importers:
       vite-plugin-inspect:
         specifier: 0.10.3
         version: 0.10.3(rollup@4.28.0)(vite@6.0.3(@types/node@22.10.1)(jiti@2.4.1)(sass@1.77.7)(terser@5.31.6)(yaml@2.6.1))
+      vue:
+        specifier: ^3.3.4
+        version: 3.5.13(typescript@5.7.2)
 
 packages:
 
@@ -6985,6 +6988,9 @@ packages:
   vue-component-type-helpers@2.1.10:
     resolution: {integrity: sha512-lfgdSLQKrUmADiSV6PbBvYgQ33KF3Ztv6gP85MfGaGaSGMTXORVaHT1EHfsqCgzRNBstPKYDmvAV9Do5CmJ07A==}
 
+  vue-component-type-helpers@2.2.0:
+    resolution: {integrity: sha512-cYrAnv2me7bPDcg9kIcGwjJiSB6Qyi08+jLDo9yuvoFQjzHiPTzML7RnkJB1+3P6KMsX/KbCD4QE3Tv/knEllw==}
+
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
     engines: {node: '>=12'}
@@ -9419,7 +9425,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.13(typescript@5.7.2)
-      vue-component-type-helpers: 2.1.10
+      vue-component-type-helpers: 2.2.0
 
   '@stylistic/eslint-plugin@2.11.0(eslint@9.16.0(jiti@2.4.1))(typescript@5.7.2)':
     dependencies:
@@ -15776,6 +15782,8 @@ snapshots:
       typescript: 5.7.2
 
   vue-component-type-helpers@2.1.10: {}
+
+  vue-component-type-helpers@2.2.0: {}
 
   vue-demi@0.14.10(vue@3.5.13(typescript@5.7.2)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,7 +348,7 @@ importers:
         specifier: 0.10.3
         version: 0.10.3(rollup@4.28.0)(vite@6.0.3(@types/node@22.10.1)(jiti@2.4.1)(sass@1.77.7)(terser@5.31.6)(yaml@2.6.1))
       vue:
-        specifier: ^3.3.4
+        specifier: 3.5.13
         version: 3.5.13(typescript@5.7.2)
 
 packages:


### PR DESCRIPTION
<!--
☝️ PR title should follow conventional commits (https://conventionalcommits.org).
In particular, the title should start with one of the following types:

- docs: 📖 Documentation (updates to the documentation or readme)
- fix: 🐞 Bug fix (a non-breaking change that fixes an issue)
- feat: ✨ New feature/enhancement (a non-breaking change that adds functionality or improves existing one)
- feat!/fix!: ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- chore: 🧹 Chore (updates to the build process or auxiliary tools and libraries)
-->

### 🔗 Linked issue


Fixes https://github.com/nuxt-modules/storybook/issues/808 and fixes https://github.com/nuxt-modules/storybook/issues/805.

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
This PR reverts #740  that removes of the vue-templation-template plugin, which was initially extended from the vue3-vite project vite config. However, removing it only masked the memory issue rather than addressing its root cause—the resolution of the vue ESM bundler alias.

The vue-templation-template plugin is essential for rendering stories with custom string templates, so we need to retain it.

To work around the memory issue and ensure template compilation works correctly, i have added vue as a dependency in the root project. ( playground )

The underlying problem appears to be related to how the vue alias is resolved. When it isn’t found in the root project, some unusual string replacement occurs, leading to recursive paths and the memory issue. Further investigation may be needed to fully understand why vue cannot be resolved from sub-packages.
