### PR TITLE
chore: fail workflow if chromatic finds changes in examples

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -61,4 +61,6 @@ jobs:
           # exitOnceUploaded: true
           projectToken: ${{ matrix.projectToken }}
           buildScriptName: ${{ matrix.storybookBuildScript }}
+          # Fail workflow if changes are found
+          exitZeroOnChanges: false
           debug: true


### PR DESCRIPTION
<!--
☝️ PR title should follow conventional commits (https://conventionalcommits.org).
In particular, the title should start with one of the following types:

- docs: 📖 Documentation (updates to the documentation or readme)
- fix: 🐞 Bug fix (a non-breaking change that fixes an issue)
- feat: ✨ New feature/enhancement (a non-breaking change that adds functionality or improves existing one)
- feat!/fix!: ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- chore: 🧹 Chore (updates to the build process or auxiliary tools and libraries)
-->

Currently the workflow passes even though there are changes in the examples. Thus, one always have to manually check the chromatic app before merging a PR, which gets tiresome.

### 🔗 Linked issue

Refs https://github.com/nuxt-modules/storybook/issues/710

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
