### PR TITLE
fix: enable cycles option when stringifying objects

### DIFF
--- a/packages/storybook-addon/src/preset.ts
+++ b/packages/storybook-addon/src/preset.ts
@@ -339,15 +339,15 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (
     console.debug(`Writing Vite configs to ${options.outputDir}/logs/...`)
     fs.writeFileSync(
       join(options.outputDir, 'logs', 'vite-storybook.config.json'),
-      stringify(storybookViteConfig, { space: '  ' }) || '',
+      stringify(storybookViteConfig, { space: '  ', cycles: true }) || '',
     )
     fs.writeFileSync(
       join(options.outputDir, 'logs', 'vite-nuxt.config.json'),
-      stringify(nuxtConfig, { space: '  ' }) || '',
+      stringify(nuxtConfig, { space: '  ', cycles: true }) || '',
     )
     fs.writeFileSync(
       join(options.outputDir, 'logs', 'vite-final.config.json'),
-      stringify(finalViteConfig, { space: '  ' }) || '',
+      stringify(finalViteConfig, { space: '  ', cycles: true }) || '',
     )
   }
 


### PR DESCRIPTION
<!--
☝️ PR title should follow conventional commits (https://conventionalcommits.org).
In particular, the title should start with one of the following types:

- docs: 📖 Documentation (updates to the documentation or readme)
- fix: 🐞 Bug fix (a non-breaking change that fixes an issue)
- feat: ✨ New feature/enhancement (a non-breaking change that adds functionality or improves existing one)
- feat!/fix!: ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- chore: 🧹 Chore (updates to the build process or auxiliary tools and libraries)
-->

### 🔗 Linked issue

Resolves #817 

### 📚 Description

Without replacing the `json-stable-stringify` dependency, we can simply enable `cycles` to properly `stringify` objects with circular references as the nuxt config object can have.
