### PR TITLE
fix: restore HMR functionality for Nuxt 3.15.3 and above

### DIFF
--- a/packages/storybook-addon/src/preset.ts
+++ b/packages/storybook-addon/src/preset.ts
@@ -87,6 +87,9 @@ async function loadNuxtViteConfig(root: string | undefined) {
       appId: 'nuxt-app',
       buildId: 'storybook',
       ssr: false,
+      vite: {
+        mode: 'development',
+      },
     },
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #891

### 📚 Description

Starting with Nuxt 3.15.3, Vite no longer initializes properly in development mode, which results in broken hot module reloading (HMR).

Explicitly set vite.mode to 'development' in the loadNuxt call to ensure Vite initializes correctly. This restores HMR functionality in Nuxt 3.15.3 and above.