### PR TITLE
docs: add warning about differences between running `storybook` with `nuxt` or on its own

### DIFF
--- a/docs/content/1.getting-started/1.setup.md
+++ b/docs/content/1.getting-started/1.setup.md
@@ -89,6 +89,10 @@ storybook dev -p 6006
 
 ::
 
+::warning
+Running Storybook on its own will result in Nuxt running on `production` mode instead of `development`. This will have an effect on any stories for components that use `<DevOnly>` or `import.meta.dev`.
+::
+
 When you install Storybook using the CLI, you will find a few stories in the `components` directory to get you started. You can add your own stories to this directory or create a new directory for your stories (in which case you will need to update the [Storybook configuration](/storybook/config)).
 The Storybook server will automatically detect changes to your stories and update the UI accordingly.
 


### PR DESCRIPTION
This PR adds a warning note to inform users about the differences between running `storybook` with `nuxt` or on its own.
