### PR TITLE
fix: 🐞 Fix semver range update in Renovate in peerDependencies breaking peer dependency compatability

### DIFF
--- a/packages/nuxt-module/package.json
+++ b/packages/nuxt-module/package.json
@@ -60,6 +60,6 @@
     "unbuild": "3.5.0"
   },
   "peerDependencies": {
-    "storybook": "9.0.5"
+    "storybook": "^9.0.5"
   }
 }

--- a/packages/nuxt-module/package.json
+++ b/packages/nuxt-module/package.json
@@ -60,6 +60,6 @@
     "unbuild": "3.5.0"
   },
   "peerDependencies": {
-    "storybook": "^9.0.5"
+    "storybook": "~9.0.5"
   }
 }

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -64,7 +64,7 @@
     "nuxt": "^3.13.0",
     "vite": "^5.2.0 || ^6.0.0",
     "vue": "^3.4.0",
-    "storybook": "^9.0.5"
+    "storybook": "~9.0.5"
   },
   "dependencies": {
     "@nuxt/kit": "^3.13.0",

--- a/packages/storybook-addon/package.json
+++ b/packages/storybook-addon/package.json
@@ -64,7 +64,7 @@
     "nuxt": "^3.13.0",
     "vite": "^5.2.0 || ^6.0.0",
     "vue": "^3.4.0",
-    "storybook": "9.0.5"
+    "storybook": "^9.0.5"
   },
   "dependencies": {
     "@nuxt/kit": "^3.13.0",

--- a/renovate.json5
+++ b/renovate.json5
@@ -29,11 +29,18 @@
   ignorePaths: ['**/node_modules/**'],
   packageRules: [
     {
-      // Pin all @storybook/* packages because even minor updates can break things for us
+      // Pin all @storybook/* packages because even minor updates can break things for us, but use different strategy for peer deps
       matchPackagePatterns: ['storybook', '@storybook/*'],
+      matchDepTypes: ['dependencies', 'devDependencies'],
       groupName: 'storybook packages',
       groupSlug: 'storybook',
       rangeStrategy: 'pin',
+    },
+    {
+      // Use bump strategy for peer dependencies to maintain compatibility and desired version ranges
+      matchPackagePatterns: ['storybook', '@storybook/*'],
+      matchDepTypes: ['peerDependencies'],
+      rangeStrategy: 'bump',
     },
     {
       // Pin all dependencies (for docs and examples) following https://docs.renovatebot.com/dependency-pinning/


### PR DESCRIPTION
<!--
☝️ PR title should follow conventional commits (https://conventionalcommits.org).
In particular, the title should start with one of the following types:

- docs: 📖 Documentation (updates to the documentation or readme)
- fix: 🐞 Bug fix (a non-breaking change that fixes an issue)
- feat: ✨ New feature/enhancement (a non-breaking change that adds functionality or improves existing one)
- feat!/fix!: ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- chore: 🧹 Chore (updates to the build process or auxiliary tools and libraries)
-->

### 🔗 Linked issue

Resolves #907

### 📚 Description

This PR fixes peerDependency storyblock dependency to use a semver range. In #882 storybook was implemented as a peer dependency to the 2 packages of this repo, and was given a range of `^9.0.4`. But then in #905 the Renovate bot updated storybook to `9.0.5`, including the peer dependency of it, and pinned the version to `9.0.5`, leading to #907
This PR fixes that

NB: Make sure that the new rule I've implemented in the Renovate config matches the group settings you want
