### PR TITLE
fix: reduce job matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Keep this in sync with the oldest Node.js version supported by the storybook
-        node: [20.19.0, 22, 24]
+        node: [20]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        include:
-          - node: 24
-            os: ubuntu-latest
-            release-nightly: true
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,13 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Keep this in sync with the oldest Node.js version supported by the storybook
-        node: [20, 21, 22, 23, 24]
+        node: [20]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        exclude:
-          # Failing: https://github.com/nuxt-modules/storybook/pull/882#issuecomment-2939100304
-          - node: 21
-            os: windows-latest
     env:
       # renovate: datasource=npm depName=storybook
       STORYBOOK_VERSION: '9.0.5'


### PR DESCRIPTION
### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description
Maybe there's a good reason for testing multiple node versions, but I would like to suggest reducing it to the lowest supported version instead (Nuxt only tests on node 20 for example). Beside it being slower (queued jobs) it also feels a bit wasteful to run so many jobs 😅
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
