### PR TITLE
fix: include config dir in tsconfig

### DIFF
--- a/packages/nuxt-module/src/storybook.ts
+++ b/packages/nuxt-module/src/storybook.ts
@@ -53,7 +53,7 @@ export async function setupStorybook(options: ModuleOptions, nuxt: Nuxt) {
   const projectDir = resolve(nuxt.options.rootDir)
   const configDir = resolve(projectDir, '.storybook')
 
-  // hoist dependency and include .storybook in tsconfig
+  // include .storybook in tsconfig
   nuxt.options.typescript = defu(nuxt.options.typescript, {
     tsConfig: {
       include: [relative(nuxt.options.buildDir, resolve(configDir, '**/*'))],

--- a/packages/nuxt-module/src/storybook.ts
+++ b/packages/nuxt-module/src/storybook.ts
@@ -1,4 +1,5 @@
-import { resolve } from 'node:path'
+import defu from 'defu'
+import { resolve, relative } from 'node:path'
 import type { Nuxt } from 'nuxt/schema'
 import { getPort } from 'get-port-please'
 import type { ModuleOptions } from './module'
@@ -50,10 +51,19 @@ export async function setupStorybook(options: ModuleOptions, nuxt: Nuxt) {
   })
 
   const projectDir = resolve(nuxt.options.rootDir)
+  const configDir = resolve(projectDir, '.storybook')
+
+  // hoist dependency and include .storybook in tsconfig
+  nuxt.options.typescript = defu(nuxt.options.typescript, {
+    hoist: ['@storybook-vue/nuxt'],
+    tsConfig: {
+      include: [relative(nuxt.options.buildDir, resolve(configDir, '**/*'))],
+    },
+  })
 
   const storybookOptions = {
     port: storybookServerPort,
-    configDir: resolve(projectDir, './.storybook'),
+    configDir,
     configType: 'DEVELOPMENT',
     cache: storybookCache,
     // Don't check for storybook updates (we're using the latest version)

--- a/packages/nuxt-module/src/storybook.ts
+++ b/packages/nuxt-module/src/storybook.ts
@@ -55,7 +55,6 @@ export async function setupStorybook(options: ModuleOptions, nuxt: Nuxt) {
 
   // hoist dependency and include .storybook in tsconfig
   nuxt.options.typescript = defu(nuxt.options.typescript, {
-    hoist: ['@storybook-vue/nuxt'],
     tsConfig: {
       include: [relative(nuxt.options.buildDir, resolve(configDir, '**/*'))],
     },


### PR DESCRIPTION
### 🔗 Linked issue
* #920 
<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description
With https://github.com/nuxt/nuxt/pull/32601 merged, the related issue will be resolved for projects using nuxt 4.

This will also improve/add support for the directory structure in nuxt 4 as the `.storybook` directory is outside the app/server directories and needs to be added manually by this module.

~~If we also want this resolved for projects using nuxt 3, the PR will either need to be backported (ideal) or we could use my package nuxt-module-utils (I have not done so in this PR, I don't want to be pushy with my own packages 😂).~~
(this is not relevant since the separated tsconfig structure is nuxt 4 only)
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
