### PR TITLE
chore:  Add Manual Major Version Bump Capability

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lint:prettier": "prettier --check .",
     "lint:fix": "pnpm lint:eslint --fix && pnpm lint:prettier --write",
     "release": "pnpm jiti prepare-release.ts && pnpm publish --recursive  && git push --follow-tags",
+    "release:major": "pnpm jiti prepare-release.ts --major && pnpm publish --recursive  && git push --follow-tags",
     "nightly-release": "pnpm jiti prepare-release.ts --nightly && pnpm publish --recursive --tag nightly --access public --no-git-checks --provenance --report-summary",
     "prepare": "pnpm run --filter=./playground/** prepare",
     "docs:dev": "pnpm run --filter=./docs/** dev",

--- a/prepare-release.ts
+++ b/prepare-release.ts
@@ -146,6 +146,12 @@ export async function determineBumpType() {
   const config = await loadChangelogConfig(process.cwd())
   const commits = await getLatestCommits()
 
+  // Check for manual major bump flag
+  if (process.argv.includes('--major')) {
+    consola.info('🚀 Manual major bump requested')
+    return 'major'
+  }
+
   const bumpType = determineSemverChange(commits, config)
 
   return bumpType === 'major' ? 'minor' : bumpType


### PR DESCRIPTION


This PR adds a simple way to manually trigger major version bumps when needed, particularly useful for ecosystem alignment (e.g., when Storybook releases a new major version).

### 🔧 **Changes**

- **Added `release:major` script** to `package.json` for forcing major version bumps
- **Updated `prepare-release.ts`** to handle `--major` flag that bypasses automatic major→minor downgrade
- **Maintains existing behavior** for automatic releases (still downgrades major to minor)

### 🚀 **Usage**

```bash
# Regular release (auto-detection, major→minor downgrade)
pnpm release

# Force major bump (new!)
pnpm release:major
```

### 🎯 **When to Use `pnpm release:major`**

- ✅ Storybook major version upgrades (v9 → v10)
- ✅ Nuxt major version upgrades (v3 → v4)
- ✅ Breaking API changes that should be properly versioned
- ✅ Any ecosystem alignment scenarios

### 💡 **Why This Approach**

- **Simple**: Just one new script, minimal code changes
- **Explicit**: Clear intent when forcing major bumps
- **Safe**: Doesn't affect existing automatic release behavior
- **Flexible**: Manual control when ecosystem alignment is needed

### 🧪 **Testing**

- [x] Existing release process unchanged
- [x] New `--major` flag properly detected in `determineBumpType()`
- [x] Script properly formatted and follows existing patterns


