### PR TITLE
chore: fix `nuxt init` in e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,13 +85,7 @@ jobs:
         shell: bash
         run: |
           cd "${{ runner.temp }}"
-          # nuxi init may exit with code 1 due to modules prompt failing on non-TTY stdin
-          # Allow failure, then verify project was created successfully
-          CI=true npx nuxi init example --template minimal --packageManager pnpm --modules --force --gitInit=false < /dev/null || true
-          if [ ! -f example/nuxt.config.ts ]; then
-            echo "Error: nuxi init failed to create project"
-            exit 1
-          fi
+          CI=true npx nuxi init example --template minimal --packageManager pnpm --modules --force --gitInit=false
           cd example
           # Configure scoped registries globally so pnpm can find our packages
           pnpm config set @nuxtjs:registry $VERDACCIO_REGISTRY


### PR DESCRIPTION
# FIX(ci): Adds option flags to `nuxi` command in CI to prevent timeouts

Adds two flags to prevent the `nuxi` CLI prompts for template and modules

Resolves: #990 

Related: https://github.com/nuxt-modules/storybook/pull/981