### PR TITLE
fix: derive the dev proxy target from the nuxt dev server address

### DIFF
--- a/packages/storybook-addon/src/preset.ts
+++ b/packages/storybook-addon/src/preset.ts
@@ -399,18 +399,37 @@ async function getPackageDir(packageName: string) {
 }
 
 export function getNuxtProxyConfig(nuxt: Nuxt) {
-  const port = nuxt.options.runtimeConfig.app.port ?? 3000
-  const route = '^/(_nuxt|_ipx|api/_nuxt_icon|__nuxt_devtools__|__nuxt_island)'
+  // The target must stay an object: the dev server often binds the IPv6
+  // loopback (http://[::1]:3000) and http-proxy cannot parse bracketed
+  // IPv6 hosts in string targets.
+  let target = { protocol: 'http:', host: 'localhost', port: 3000 }
+  const devServer = nuxt.options.devServer
+  if (devServer?.url) {
+    const url = new URL(devServer.url)
+    target = {
+      protocol: url.protocol,
+      // WHATWG URL keeps IPv6 literals bracketed; net.connect wants them raw
+      host: url.hostname.replace(/^\[|\]$/g, ''),
+      port: Number(url.port || (url.protocol === 'https:' ? 443 : 80)),
+    }
+  } else if (devServer?.port) {
+    target = { protocol: 'http:', host: 'localhost', port: devServer.port }
+  }
+
+  // /_nuxt/builds/meta (app manifest) is excluded: those files are specific
+  // to the Storybook build and must not be answered by the Nuxt app
+  const route =
+    '^/(_nuxt(?!/builds/meta)|_ipx|api/_nuxt_icon|__nuxt_devtools__|__nuxt_island)'
   const proxy = {
     [route]: {
-      target: `http://localhost:${port}`,
+      target,
       changeOrigin: true,
       secure: false,
       ws: true,
     },
   }
   return {
-    port,
+    target,
     route,
     proxy,
   }

--- a/test/proxy-config.spec.ts
+++ b/test/proxy-config.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import type { Nuxt } from '@nuxt/schema'
+import { getNuxtProxyConfig } from '../packages/storybook-addon/src/preset'
+
+/**
+ * Unit tests for the Storybook→Nuxt dev proxy configuration.
+ *
+ * The proxy target must be the dev server's actual address
+ * (nuxt.options.devServer.url): the previous hardcoded localhost:3000
+ * broke whenever Nuxt listened elsewhere (#993). The target is an object
+ * (protocol/host/port) because http-proxy cannot parse bracketed IPv6
+ * hosts like http://[::1]:3000 in string targets.
+ */
+
+function mockNuxt(devServer?: { url?: string; port?: number }): Nuxt {
+  return {
+    options: {
+      devServer: devServer ?? {},
+      runtimeConfig: { app: {} },
+    },
+  } as unknown as Nuxt
+}
+
+describe('getNuxtProxyConfig', () => {
+  it('targets the dev server url', () => {
+    const { target, proxy } = getNuxtProxyConfig(
+      mockNuxt({ url: 'http://127.0.0.1:54321/' }),
+    )
+    expect(target).toEqual({
+      protocol: 'http:',
+      host: '127.0.0.1',
+      port: 54321,
+    })
+    expect(Object.values(proxy)[0]?.target).toEqual(target)
+  })
+
+  it('unwraps bracketed IPv6 hosts', () => {
+    const { target } = getNuxtProxyConfig(
+      mockNuxt({ url: 'http://[::1]:3000/' }),
+    )
+    expect(target).toEqual({ protocol: 'http:', host: '::1', port: 3000 })
+  })
+
+  it('falls back to the dev server port when no url is available', () => {
+    const { target } = getNuxtProxyConfig(mockNuxt({ port: 4000 }))
+    expect(target).toEqual({ protocol: 'http:', host: 'localhost', port: 4000 })
+  })
+
+  it('falls back to localhost:3000 when devServer has neither url nor port', () => {
+    const { target } = getNuxtProxyConfig(mockNuxt())
+    expect(target).toEqual({ protocol: 'http:', host: 'localhost', port: 3000 })
+  })
+
+  it('proxies /_nuxt assets but not the app manifest', () => {
+    const { route } = getNuxtProxyConfig(mockNuxt())
+    const matcher = new RegExp(route)
+
+    expect('/_nuxt/some/asset.js').toMatch(matcher)
+    expect('/_nuxt/@vite/client').toMatch(matcher)
+    expect('/_ipx/w_100/img.png').toMatch(matcher)
+    // App manifest files are specific to the Storybook build and must not
+    // be answered by the Nuxt app
+    expect('/_nuxt/builds/meta/storybook.json').not.toMatch(matcher)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Refs #993 — together with #1069 this completes the fix for that issue. Carries forward the proxy-target portion of #994, as offered [there](https://github.com/nuxt-modules/storybook/pull/994#issuecomment-4695132730); credit to @akornmeier for the original diagnosis (co-authored on the commit).

### 📚 Description

The Storybook→Nuxt dev asset proxy (`getNuxtProxyConfig`) targeted `runtimeConfig.app.port ?? 3000` — that runtime-config field is virtually never set, so the proxy always pointed at hardcoded `localhost:3000` and broke whenever the dev server listened anywhere else. With the startup deadlock fixed (#1069), this surfaces immediately as the `EAGAIN` errors on `/_nuxt/*` reported in #993.

**Changes** (deliberately only the proxy-target portion of #994, per the review feedback there — the unhead/appManifest changes are left out for separate discussion):

- Target the dev server's actual address from `nuxt.options.devServer.url` (falling back to `devServer.port`, then `localhost:3000`).
- Pass the target as a `{ protocol, host, port }` object rather than a URL string: the dev server frequently binds the IPv6 loopback (`http://[::1]:3000`), and `http-proxy` cannot parse bracketed IPv6 hosts in string targets — it attempts to resolve the literal `[::1]` and fails with `ENOTFOUND`. This is likely why testing the original #994 kept producing unexplained failures.
- Exclude `/_nuxt/builds/meta` (app manifest) from the proxy route: those files are specific to the Storybook build and must not be answered by the Nuxt app.

**Tests:** new unit suite for `getNuxtProxyConfig` covering the URL-derived target, the bracketed-IPv6 unwrapping, both fallbacks, and the route regex (proxies `/_nuxt/*` and `/_ipx/*`, excludes `/_nuxt/builds/meta/*`).

Verified in combination with #1069 against the #993 reproduction (braedenfoster/storybook-test-nuxt-4): the proxy reaches the dev server with zero `EAGAIN`/`ENOTFOUND` errors logged.

*(investigated and fixed with Claude Fable 5 assistance)*
